### PR TITLE
fix 2 exit prompts showing when cancelling the installation

### DIFF
--- a/Rectify11Installer/frmWizard.cs
+++ b/Rectify11Installer/frmWizard.cs
@@ -231,17 +231,13 @@ namespace Rectify11Installer
 		#region Private Methods
 		private void CancelButton_Click(object sender, EventArgs e)
 		{
-			// will be replaced with taskdialog.
-			DialogResult ok = MessageBox.Show(resources.GetString("exitText"), resources.GetString("Title"), MessageBoxButtons.YesNo, MessageBoxIcon.Information);
-			if (ok == DialogResult.Yes)
-			{
-				Application.Exit();
-			}
+			Application.Exit();
 		}
 		private void frmWizard_FormClosing(object sender, FormClosingEventArgs e)
 		{
 			if (!Variables.isInstall)
 			{
+				// will be replaced with taskdialog.
 				DialogResult ok = MessageBox.Show(resources.GetString("exitText"), resources.GetString("Title"), MessageBoxButtons.YesNo, MessageBoxIcon.Information);
 				if (ok == DialogResult.No)
 				{


### PR DESCRIPTION
When the cancel button was pressed 2 prompts asking you if you want to exit were shown.