### PR TITLE
Remove space after DisplayName on Mica theme

### DIFF
--- a/Resources/Themes/themes/black.theme
+++ b/Resources/Themes/themes/black.theme
@@ -2,7 +2,7 @@
 
 [Theme]
 ; Windows - IDS_THEME_DISPLAYNAME_RECTIFIEDBLACK
-DisplayName=Rectify11 Dark theme with Mica 
+DisplayName=Rectify11 Dark theme with Mica
 SetLogonBackground=0
 
 ; Computer - SHIDI_SERVER


### PR DESCRIPTION
There is a blank space after `Rectify11 Dark theme with Mica` on the `DisplayName` line. This simply removes that space.