### PR TITLE
An update for theme.nss

### DIFF
--- a/Resources/Extras/Nilesoft/imports/theme.nss
+++ b/Resources/Extras/Nilesoft/imports/theme.nss
@@ -1,4 +1,4 @@
-﻿theme
+theme
 {
 	name = "modern"
 	dark = sys.dark
@@ -9,4 +9,52 @@
 		effect = default
 	}
 	image.align = 2
+	image.color = theme.islight ? [auto, color.accent] : [auto, color.accent_light2]
+	
+	item
+	{
+		opacity = 50
+		radius = 1
+		prefix = 0
+		padding = [10, 4]
+		margin = [4,2]
+	}
+
+	separator
+	{
+		size = 1
+		color = default
+		opacity = default
+		margin = [0,1]
+	}
+
+	border
+	{
+		enabled = 1
+		size = 1
+		color = #000
+		opacity = theme.islight ? 12 : 25
+		radius = default
+		padding = [0,2]
+	}
+
+	shadow
+	{
+		enabled = 1
+		size = 7
+		color = default
+		opacity = theme.islight ? default : 7
+		offset = 8
+	}
+
+	font
+	{
+		name = "Segoe UI Variable Text"
+	}
+
+	layout
+	{
+		popup = -5
+	}
+
 }


### PR DESCRIPTION
### With this change made on theme.nss, it will look more closely match the default Windows 11 context menu design:
- Adjusted border, prefix, separator and orientation.
- Repainted both border and shadows (It adjusts atomically, depending on whether it is in light or dark mode).
- Font set to **“Segoe UI Variable Text”**, the same font used for the W11 default context menu.
- In addition, **accent colours** have been added to the glyph icons (it works in both light and dark mode).

**Example:**
![github_difference1](https://github.com/user-attachments/assets/bc581e44-e52d-4a82-854e-ad0df56af1db)
_PD: This is a small change, but it is beneficial for consistency._